### PR TITLE
Use npm scripts instead of grunt and bower CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 git clone https://github.com/SAP/openui5-sample-app.git
 cd openui5-sample-app
 ```
-* Install all npm dependencies
+* Install all npm dependencies (also installs all bower dependencies)
 ```sh
 npm install
 ```

--- a/README.md
+++ b/README.md
@@ -6,26 +6,22 @@
 
 ## Getting started
 
-1. Install node.js (get it from [nodejs.org](http://nodejs.org/)).
+* Install node.js (get it from [nodejs.org](http://nodejs.org/)).
   * If working behind a proxy, you need to configure it properly (HTTP_PROXY / HTTPS_PROXY / NO_PROXY environment variables)
 
-2. Clone the repository and navigate into it
-
+* Clone the repository and navigate into it
 ```sh
 git clone https://github.com/SAP/openui5-sample-app.git
 cd openui5-sample-app
 ```
-
-3. Install all npm dependencies
-
+* Install all npm dependencies
 ```sh
 npm install
 ```
 
-4. Run npm start to lint, build and run a local server (have a look into `Gruntfile.js` to see all the tasks).
-
+* Run npm start to lint, build and run a local server (have a look into `Gruntfile.js` to see all the tasks).
 ```sh
 npm start
 ```
 
-6. Open the app in your browser: [http://localhost:8080](http://localhost:8080)
+* Open the app in your browser: [http://localhost:8080](http://localhost:8080)

--- a/README.md
+++ b/README.md
@@ -8,34 +8,24 @@
 
 1. Install node.js (get it from [nodejs.org](http://nodejs.org/)).
   * If working behind a proxy, you need to configure it properly (HTTP_PROXY / HTTPS_PROXY / NO_PROXY environment variables)
-2. Install grunt-cli and bower globally
 
-   ```sh
-npm install grunt-cli bower -g
-```
-3. Clone the repository and navigate into it
+2. Clone the repository and navigate into it
 
-   ```sh
+```sh
 git clone https://github.com/SAP/openui5-sample-app.git
 cd openui5-sample-app
 ```
 
-1. Install all npm dependencies
+3. Install all npm dependencies
 
-   ```sh
+```sh
 npm install
 ```
 
-1. Install all bower dependencies
+4. Run npm start to lint, build and run a local server (have a look into `Gruntfile.js` to see all the tasks).
 
-   ```sh
-bower install
-```
-
-5. Run grunt to lint, build and run a local server (have a look into `Gruntfile.js` to see all the tasks).
-
-   ```sh
-grunt
+```sh
+npm start
 ```
 
 6. Open the app in your browser: [http://localhost:8080](http://localhost:8080)

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "postinstall": "bower install",
-    "ui5": "grunt"
+    "start": "grunt"
   },
   "devDependencies": {
     "bower": "^1.8.0",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Sample of an OpenUI5 app",
   "private": true,
   "scripts": {
+    "test": "echo \"Error: no test specified. Please add some.\" && exit 1",
     "postinstall": "bower install",
     "start": "grunt"
   },

--- a/package.json
+++ b/package.json
@@ -4,9 +4,11 @@
   "description": "Sample of an OpenUI5 app",
   "private": true,
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "postinstall": "bower install",
+    "ui5": "grunt"
   },
   "devDependencies": {
+    "bower": "^1.8.0",
     "grunt": "^1.0.1",
     "grunt-contrib-clean": "^1.0.0",
     "grunt-contrib-connect": "^1.0.2",


### PR DESCRIPTION
The usage of grunt and bower as globally installed CLI tools is not
always the optimal way. It requires administrator rights and all node
projects are forced to the same bower and grunt version.
By using npm package scripts you don’t longer need globally installed
node packages.
The UI5 sources are downloaded through bower automatically with 
```
npm install
```

Grunt can be started with the command 
```
npm start ui5
```