### PR TITLE
Fix Component-preload namespace prefix

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -46,7 +46,7 @@ module.exports = function(grunt) {
 				options: {
 					resources: {
 						cwd: 'webapp',
-						prefix: 'sap.ui.demo.todo',
+						prefix: 'sap/ui/demo/todo',
 						src: [
 							'**/*.js',
 							'**/*.fragment.html',


### PR DESCRIPTION
Although there was no error when creating the Component-preload, it
didn't register the resources with the correct namespaces, so all single
files were still loaded.
The namespace prefix must be separated by "/", not "."