### PR TITLE
Use UTF-8 encoding in i18n files

### DIFF
--- a/ui5.yaml
+++ b/ui5.yaml
@@ -2,3 +2,6 @@ specVersion: '1.0'
 metadata:
   name: openui5-sample-app
 type: application
+resources:
+  configuration:
+    propertiesFileSourceEncoding: "UTF-8"

--- a/webapp/i18n/i18n_de.properties
+++ b/webapp/i18n/i18n_de.properties
@@ -1,5 +1,5 @@
 TITLE=Todos
 INPUT_PLACEHOLDER=Was muss getan werden?
-ITEM_LEFT=Eintrag \u00fcbrig
-ITEMS_LEFT=Eintr\u00e4ge \u00fcbrig
-CLEAR_COMPLETED=Erledigte Eintr\u00e4ge entfernen
+ITEM_LEFT=Eintrag übrig
+ITEMS_LEFT=Einträge übrig
+CLEAR_COMPLETED=Erledigte Einträge entfernen


### PR DESCRIPTION
To test, execute `npm install && npm start` and open http://localhost:8080/index.html?sap-language=de