### PR TITLE
ui5 tooling v3

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,12 +1,18 @@
 {
+	"root": true,
+	"extends": ["eslint:recommended"],
 	"env": {
-		"browser": true
+		"browser": true,
+		"es6": true,
+		"jquery": true,
+		"qunit": true
 	},
 	"globals": {
 		"sap": true,
-		"jQuery": true
+		"sinon": true
 	},
 	"rules": {
+		"no-var": "error",
 		"block-scoped-var": 1,
 		"brace-style": [2, "1tbs", { "allowSingleLine": true }],
 		"consistent-this": 2,

--- a/ui5.yaml
+++ b/ui5.yaml
@@ -1,4 +1,4 @@
-specVersion: '2.0'
+specVersion: '3.0'
 metadata:
   name: openui5-sample-app
 type: application

--- a/webapp/controller/App.controller.js
+++ b/webapp/controller/App.controller.js
@@ -23,8 +23,8 @@ sap.ui.define([
 		 * Adds a new todo item to the bottom of the list.
 		 */
 		addTodo: function() {
-			var oModel = this.getView().getModel();
-			var aTodos = oModel.getProperty("/todos").map(function (oTodo) { return Object.assign({}, oTodo); });
+			let oModel = this.getView().getModel();
+			let aTodos = oModel.getProperty("/todos").map(function (oTodo) { return Object.assign({}, oTodo); });
 
 			aTodos.push({
 				title: oModel.getProperty("/newTodo"),
@@ -39,12 +39,12 @@ sap.ui.define([
 		 * Removes all completed items from the todo list.
 		 */
 		clearCompleted: function() {
-			var oModel = this.getView().getModel();
-			var aTodos = oModel.getProperty("/todos").map(function (oTodo) { return Object.assign({}, oTodo); });
+			let oModel = this.getView().getModel();
+			let aTodos = oModel.getProperty("/todos").map(function (oTodo) { return Object.assign({}, oTodo); });
 
-			var i = aTodos.length;
+			let i = aTodos.length;
 			while (i--) {
-				var oTodo = aTodos[i];
+				let oTodo = aTodos[i];
 				if (oTodo.completed) {
 					aTodos.splice(i, 1);
 				}
@@ -57,10 +57,10 @@ sap.ui.define([
 		 * Updates the number of items not yet completed
 		 */
 		updateItemsLeftCount: function() {
-			var oModel = this.getView().getModel();
-			var aTodos = oModel.getProperty("/todos") || [];
+			let oModel = this.getView().getModel();
+			let aTodos = oModel.getProperty("/todos") || [];
 
-			var iItemsLeft = aTodos.filter(function(oTodo) {
+			let iItemsLeft = aTodos.filter(function(oTodo) {
 				return oTodo.completed !== true;
 			}).length;
 
@@ -72,7 +72,7 @@ sap.ui.define([
 		 * @param {sap.ui.base.Event} oEvent Input changed event
 		 */
 		onSearch: function(oEvent) {
-			var oModel = this.getView().getModel();
+			let oModel = this.getView().getModel();
 
 			// First reset current filters
 			this.aSearchFilters = [];
@@ -81,7 +81,7 @@ sap.ui.define([
 			this.sSearchQuery = oEvent.getSource().getValue();
 			if (this.sSearchQuery && this.sSearchQuery.length > 0) {
 				oModel.setProperty("/itemsRemovable", false);
-				var filter = new Filter("title", FilterOperator.Contains, this.sSearchQuery);
+				let filter = new Filter("title", FilterOperator.Contains, this.sSearchQuery);
 				this.aSearchFilters.push(filter);
 			} else {
 				oModel.setProperty("/itemsRemovable", true);
@@ -114,12 +114,12 @@ sap.ui.define([
 		},
 
 		_applyListFilters: function() {
-			var oList = this.byId("todoList");
-			var oBinding = oList.getBinding("items");
+			let oList = this.byId("todoList");
+			let oBinding = oList.getBinding("items");
 
 			oBinding.filter(this.aSearchFilters.concat(this.aTabFilters), "todos");
 
-			var sI18nKey;
+			let sI18nKey;
 			if (this.sFilterKey && this.sFilterKey !== "all") {
 				if (this.sFilterKey === "active") {
 					sI18nKey = "ACTIVE_ITEMS";
@@ -134,9 +134,9 @@ sap.ui.define([
 				sI18nKey = "ITEMS_CONTAINING";
 			}
 
-			var sFilterText;
+			let sFilterText;
 			if (sI18nKey) {
-				var oResourceBundle = this.getView().getModel("i18n").getResourceBundle();
+				let oResourceBundle = this.getView().getModel("i18n").getResourceBundle();
 				sFilterText = oResourceBundle.getText(sI18nKey, [this.sSearchQuery]);
 			}
 

--- a/webapp/manifest.json
+++ b/webapp/manifest.json
@@ -1,5 +1,5 @@
 {
-	"_version": "1.12.0",
+	"_version": "1.56.0",
 	"sap.app": {
 		"id": "sap.ui.demo.todo",
 		"type": "application"

--- a/webapp/test/integration/FilterJourney.js
+++ b/webapp/test/integration/FilterJourney.js
@@ -1,5 +1,3 @@
-/* global QUnit */
-
 sap.ui.define([
 	"sap/ui/test/opaQunit",
 	"sap/ui/demo/todo/test/integration/pages/App"

--- a/webapp/test/integration/SearchJourney.js
+++ b/webapp/test/integration/SearchJourney.js
@@ -1,5 +1,3 @@
-/* global QUnit */
-
 sap.ui.define([
 	"sap/ui/Device",
 	"sap/ui/test/opaQunit",

--- a/webapp/test/integration/TodoListJourney.js
+++ b/webapp/test/integration/TodoListJourney.js
@@ -1,5 +1,3 @@
-/* global QUnit */
-
 sap.ui.define([
 	"sap/ui/test/opaQunit",
 	"sap/ui/demo/todo/test/integration/pages/App"

--- a/webapp/test/integration/opaTests.qunit.js
+++ b/webapp/test/integration/opaTests.qunit.js
@@ -1,5 +1,3 @@
-/* global QUnit */
-
 QUnit.config.autostart = false;
 
 sap.ui.getCore().attachInit(function () {

--- a/webapp/test/integration/pages/App.js
+++ b/webapp/test/integration/pages/App.js
@@ -10,12 +10,12 @@ sap.ui.require([
 ], function (Device, Opa5, AggregationLengthEquals, PropertyStrictEquals, Ancestor, Properties, EnterText, Press) {
 	"use strict";
 
-	var sViewName = "sap.ui.demo.todo.view.App";
-	var sAddToItemInputId = "addTodoItemInput";
-	var sSearchTodoItemsInputId = "searchTodoItemsInput";
-	var sItemListId = "todoList";
-	var sToolbarId = Device.browser.mobile ? "toolbar-footer" : "toolbar";
-	var sClearCompletedId = Device.browser.mobile ? "clearCompleted-footer" : "clearCompleted";
+	let sViewName = "sap.ui.demo.todo.view.App";
+	let sAddToItemInputId = "addTodoItemInput";
+	let sSearchTodoItemsInputId = "searchTodoItemsInput";
+	let sItemListId = "todoList";
+	let sToolbarId = Device.browser.mobile ? "toolbar-footer" : "toolbar";
+	let sClearCompletedId = Device.browser.mobile ? "clearCompleted-footer" : "clearCompleted";
 
 	Opa5.createPageObjects({
 		onTheAppPage: {
@@ -44,8 +44,8 @@ sap.ui.require([
 						viewName: sViewName,
 						// selectionChange
 						actions: [function(oList) {
-							var iLength = oList.getItems().length;
-							var oListItem = oList.getItems()[iLength - 1].getContent()[0].getItems()[0];
+							let iLength = oList.getItems().length;
+							let oListItem = oList.getItems()[iLength - 1].getContent()[0].getItems()[0];
 							this._triggerCheckboxSelection(oListItem, bSelected);
 						}.bind(this)],
 						errorMessage: "Last checkbox cannot be pressed"
@@ -58,7 +58,7 @@ sap.ui.require([
 						actions: [function(oList) {
 
 							oList.getItems().forEach(function(oListItem) {
-								var oCheckbox = oListItem.getContent()[0].getItems()[0];
+								let oCheckbox = oListItem.getContent()[0].getItems()[0];
 								this._triggerCheckboxSelection(oCheckbox, bSelected)
 
 							}.bind(this));
@@ -69,7 +69,7 @@ sap.ui.require([
 				_triggerCheckboxSelection: function(oListItem, bSelected) {
 					//determine existing selection state and ensure that it becomes <code>bSelected</code>
 					if (oListItem.getSelected() && !bSelected || !oListItem.getSelected() && bSelected) {
-						var oPress = new Press();
+						let oPress = new Press();
 						//search within the CustomListItem for the checkbox id ending with 'selectMulti-CB'
 						oPress.controlAdapters["sap.m.CustomListItem"] = "selectMulti-CB";
 						oPress.executeOn(oListItem);
@@ -105,7 +105,7 @@ sap.ui.require([
 								controlType: "sap.m.ToggleButton",
 								visible: false,
 								success: function (aToggleButtons) {
-									var oToggleButton = aToggleButtons.find(function(oButton) {
+									let oToggleButton = aToggleButtons.find(function(oButton) {
 										return oButton.getId().startsWith(oToolbar.getId()) && oButton.getParent() === oToolbar;
 									});
 									if (oToggleButton) {
@@ -132,8 +132,8 @@ sap.ui.require([
 							name: "items",
 							length: iItemCount
 						}), function(oControl) {
-							var iLength = oControl.getItems().length;
-							var oInput = oControl.getItems()[iLength - 1].getContent()[0].getItems()[1].getItems()[0];
+							let iLength = oControl.getItems().length;
+							let oInput = oControl.getItems()[iLength - 1].getContent()[0].getItems()[1].getItems()[0];
 							return new PropertyStrictEquals({
 								name: "text",
 								value: sLastAddedText
@@ -150,8 +150,8 @@ sap.ui.require([
 						id: sItemListId,
 						viewName: sViewName,
 						matchers: [function(oControl) {
-							var iLength = oControl.getItems().length;
-							var oCheckbox = oControl.getItems()[iLength - 1].getContent()[0].getItems()[0];
+							let iLength = oControl.getItems().length;
+							let oCheckbox = oControl.getItems()[iLength - 1].getContent()[0].getItems()[0];
 							return bSelected && oCheckbox.getSelected() || !bSelected && !oCheckbox.getSelected();
 						}],
 						success: function() {
@@ -168,7 +168,7 @@ sap.ui.require([
 							name: "items",
 							length: 1
 						}), function(oControl) {
-							var oInput = oControl.getItems()[0].getContent()[0].getItems()[1].getItems()[0];
+							let oInput = oControl.getItems()[0].getContent()[0].getItems()[1].getItems()[0];
 							return new PropertyStrictEquals({
 								name: "text",
 								value: sLastItemText

--- a/webapp/test/unit/controller/App.controller.js
+++ b/webapp/test/unit/controller/App.controller.js
@@ -36,7 +36,7 @@ sap.ui.define([
 		assert.deepEqual(this.oAppController.aSearchFilters, [], "Search filters have been instantiated empty");
 		assert.deepEqual(this.oAppController.aTabFilters, [], "Tab filters have been instantiated empty");
 
-		var oModel = this.oAppController.getView().getModel("view").getData();
+		let oModel = this.oAppController.getView().getModel("view").getData();
 		assert.deepEqual(oModel, {isMobile: Device.browser.mobile, filterText: undefined});
 	});
 
@@ -76,7 +76,7 @@ sap.ui.define([
 
 	QUnit.test("Should toggle the completed items in the model", function(assert) {
 		// Arrange
-		var oModelData = {
+		let oModelData = {
 			todos: [{
 				"title": "Start this app",
 				"completed": false
@@ -99,7 +99,7 @@ sap.ui.define([
 
 	QUnit.test("Should clear the completed items", function(assert) {
 		// Arrange
-		var oModelData = {
+		let oModelData = {
 			todos: [{
 				"title": "Start this app1",
 				"completed": false
@@ -127,7 +127,7 @@ sap.ui.define([
 
 	QUnit.test("Should update items left count when no todos are loaded, yet", function(assert) {
 		// Arrange
-		var oModelData = {};
+		let oModelData = {};
 		this.oJSONModelStub.setData(oModelData);
 
 		// initial assumption
@@ -178,7 +178,7 @@ sap.ui.define([
 
 		QUnit.test("Empty search", function (assert) {
 			// Setup
-			var oEvent = { getSource: function () {
+			let oEvent = { getSource: function () {
 				return { getValue: function () { return ""; } };
 			}};
 
@@ -208,8 +208,8 @@ sap.ui.define([
 
 		QUnit.test("Do a search", function (assert) {
 			// Setup
-			var sSearchQuery = "ToDo item";
-			var oEvent = { getSource: function () {
+			let sSearchQuery = "ToDo item";
+			let oEvent = { getSource: function () {
 				return { getValue: function () {
 					return sSearchQuery;
 				}};
@@ -276,8 +276,8 @@ sap.ui.define([
 
 		QUnit.test("Toggle filters", function (assert) {
 			// Setup
-			var sKey = "";
-			var oEvent = { getParameter: function () {
+			let sKey = "";
+			let oEvent = { getParameter: function () {
 				return { getKey: function () { return sKey; } };
 			}};
 

--- a/webapp/test/unit/unitTests.qunit.js
+++ b/webapp/test/unit/unitTests.qunit.js
@@ -1,5 +1,3 @@
-/* global QUnit */
-
 QUnit.config.autostart = false;
 
 sap.ui.getCore().attachInit(function () {


### PR DESCRIPTION
ui5 tooling v3 + better `eslint` rules.

I was going to remove almost everything from `eslint`, but I thought it'd be simpler to just make minor changes.

This'd be the proposed rules:

```yaml
root: true
extends:
  - eslint:recommended
env:
  browser: true
  es6: true
  jquery: true
  qunit: true
globals:
  sap: true
  sinon: true
rules:
  no-var: error
```