### PR TITLE
[BREAKING] Drop node v18, v21

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -14,10 +14,10 @@ jobs:
 
     - uses: actions/checkout@v4
 
-    - name: Use Node.js LTS 16.18.0
+    - name: Use Node.js LTS 20.11.0
       uses: actions/setup-node@v4
       with:
-        node-version: 16.18.0
+        node-version: 20.11.0
 
     - name: Install dependencies
       run: npm ci

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
 	"name": "openui5-sample-app",
-	"version": "0.4.0",
+	"version": "0.5.0",
 	"description": "Sample of an OpenUI5 app",
 	"private": true,
 	"engines": {
-		"node": ">=18.14.0",
-		"npm": ">=9"
+		"node": "^20.11.0 || >=22.0.0",
+		"npm": ">= 8"
 	},
 	"scripts": {
 		"start": "ui5 serve",


### PR DESCRIPTION
BREAKING CHANGE:
Support for older Node.js has been dropped.
Only Node.js 20.11.x and >=22.0.0 as well as npm v8 or higher are supported.

JIRA: CPOUI5FOUNDATION-846
