### PR TITLE
ci(renovate): Set rangeStrategy to 'bump'

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,7 @@
 		"config:recommended",
 		"github>ui5/renovate-config"
 	],
+	"rangeStrategy": "bump",
 	"lockFileMaintenance": {
 		"enabled": true,
 		"automerge": true,


### PR DESCRIPTION
Also update `package.json` in case an update is available.

See https://docs.renovatebot.com/configuration-options/#rangestrategy.